### PR TITLE
deleted erroneous and duplicate line

### DIFF
--- a/src/ios/sdk/IDMMobileSDKv2/OMOIDCConfiguration.m
+++ b/src/ios/sdk/IDMMobileSDKv2/OMOIDCConfiguration.m
@@ -97,7 +97,6 @@
     {
         self.issuer = [config valueForKey:OM_PROP_ISSUER];
         self.userInfoEndpoint = [NSURL URLWithString:[config valueForKey:OM_PROP_USERINFO_ENDPOINT]];
-        self.revocationEndpoint = [NSURL URLWithString:[config valueForKey:OM_PROP_USERINFO_ENDPOINT]];
         self.revocationEndpoint = [NSURL URLWithString:[config valueForKey:OM_PROP_REVOCATION_ENDPOINT]];
         self.introspectionEndpoint = [NSURL URLWithString:[config valueForKey:OM_PROP_INTROSPECT_ENDPOINT]];
         self.endSessionEndpoint = [NSURL URLWithString:[config valueForKey:OM_PROP_END_SESSION_ENDPOINT]];


### PR DESCRIPTION
revocationEndpoint gets set twice.  The first line sets it erroneously to the wrong key.  The second line is correct.  I deleted the erroneous line.

Hello developer,

Before completing the submission of this Pull Request, we encourage you to first open an Issue. You may find it easier first describing the problem you encountered and its cause to the developers of this project, and we will work together in identifying the best way to fix it.

If you have already discussed the issue and is now proposing a fix, make sure you have your signed [Oracle Contributor Agreement](https://www.oracle.com/technetwork/community/oca-486395.html) accepted.

If everything is ok, make sure the bottom of your commit message has the following line using your name and e-mail address as it appears in the OCA Signatories list.

```
Signed-off-by: Your Name <you@example.org>
```

This can be automatically added to pull requests by committing with:

```
git commit --signoff
````

Once more, thank you for your contribution!

Oracle GitHub Team
